### PR TITLE
Use prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-metrics-service",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "React adapter for metrics services like Google Analytics, Tealium or Comcast.",
   "main": "dist/index.js",
   "scripts": {
@@ -34,8 +34,11 @@
   },
   "homepage": "https://github.com/team-767/react-metrics-service#readme",
   "dependencies": {
-    "react": ">= 0.14",
-    "recompose": ">= 0.19.0 < 1.0"
+    "recompose": ">= 0.19.0 < 1.0",
+    "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "react": "^15.5.0"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",
@@ -48,7 +51,7 @@
     "babel-preset-stage-0": "^6.5.0",
     "babelify": "^7.3.0",
     "budo": "^8.3.0",
-    "enzyme": "^2.2.0",
+    "enzyme": "^2.8.2",
     "eslint": "^2.9.0",
     "eslint-config-airbnb": "^9.0.1",
     "eslint-plugin-import": "^1.7.0",
@@ -56,7 +59,7 @@
     "eslint-plugin-react": "^5.0.1",
     "jest-cli": "^13.0.0",
     "react": "^15.0.0",
-    "react-addons-test-utils": "^15.0.0",
+    "react-test-renderer": "^15.0.0",
     "react-dom": "^15.0.0",
     "webpack": "^1.13.0"
   },
@@ -64,7 +67,6 @@
     "unmockedModulePathPatterns": [
       "react",
       "react-dom",
-      "react-addons-test-utils",
       "fbjs",
       "enzyme"
     ],

--- a/src/helpers/metrics-service-click.js
+++ b/src/helpers/metrics-service-click.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import wrapDisplayName from 'recompose/wrapDisplayName'
 
 const metricsServiceClick = (

--- a/src/helpers/metrics-service-context.js
+++ b/src/helpers/metrics-service-context.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 
 class MetricsServiceContext extends Component {
   static propTypes = {

--- a/src/helpers/with-metrics-service-client.js
+++ b/src/helpers/with-metrics-service-client.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import wrapDisplayName from 'recompose/wrapDisplayName'
 
 const withMetricsServiceClient = ({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,30 +9,31 @@ module.exports = {
     path: path.resolve(__dirname, './dist'),
     filename: 'bundle.js',
     library: 'MetricsService',
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
   },
   externals: {
-    'react': 'react'
+    react: 'react',
+    'prop-types': 'prop-types',
   },
   module: {
     loaders: [
       {
         test: /src\/.+.js$/,
         exclude: /node_modules/,
-        loader: 'babel'
-      }
-    ]
+        loader: 'babel',
+      },
+    ],
   },
   resolve: {
-    extensions: ['', '.js', '.jsx']
+    extensions: ['', '.js', '.jsx'],
   },
   plugins: [
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.optimize.UglifyJsPlugin({
       compressor: {
         screw_ie8: true,
-        warnings: false
-      }
-    })
-  ]
+        warnings: false,
+      },
+    }),
+  ],
 }


### PR DESCRIPTION
Importing PropTypes from main React package causes warnings in react >15.5 and will be deprecated in 16. 